### PR TITLE
Improve RISC-V support more

### DIFF
--- a/config/build-bindings.xml
+++ b/config/build-bindings.xml
@@ -18,6 +18,7 @@ This script is included in /config/build-definitions.xml.
     <condition property="binding.bgfx" value="true" else="false">
         <or>
             <isset property="build.arch.x86_family"/>
+            <isset property="build.arch.riscv64"/>
             <and>
                 <isset property="build.arch.arm"/>
                 <not><isset property="platform.windows"/></not>
@@ -67,6 +68,7 @@ This script is included in /config/build-definitions.xml.
         <or>
             <isset property="build.arch.x86_family"/>
             <isset property="build.arch.arm"/>
+            <isset property="build.arch.riscv64"/>
         </or>
     </condition>
     <property name="binding.shaderc" value="true"/>

--- a/config/build-definitions.xml
+++ b/config/build-definitions.xml
@@ -365,7 +365,7 @@ This script is included in /build.xml and /config/update-dependencies.xml.
         <attribute name="artifact"/>
 
         <sequential>
-            <sequential if:true="${binding.@{module}}">
+            <sequential if:true="${binding.@{module}}" unless:set="build.offline">
                 <local name="dest"/>
                 <property name="dest" value="${lib.native}/${module.@{module}.path}"/>
                 <mkdir dir="${dest}"/>

--- a/modules/lwjgl/rpmalloc/src/main/c/rpmalloc.c
+++ b/modules/lwjgl/rpmalloc/src/main/c/rpmalloc.c
@@ -808,6 +808,8 @@ get_thread_id(void) {
 #    else
 	__asm__ volatile ("mrs %0, tpidr_el0" : "=r" (tid));
 #    endif
+#  elif defined(__riscv)
+    __asm__ volatile ("mv %0, tp" : "=r" (tid));
 #  else
 #    error This platform needs implementation of get_thread_id()
 #  endif


### PR DESCRIPTION
Changes:
- Adds riscv64 to the list of arches that build rpmalloc and BGFX
- Changes `LWJGL_BUILD_OFFLINE` to apply to deps for testing too
- Implement an assembly version of `get_thread_id` for rpmalloc